### PR TITLE
Updated minesweeper

### DIFF
--- a/src/minesweeper/main.rs
+++ b/src/minesweeper/main.rs
@@ -193,6 +193,7 @@ impl<R: Iterator<Item=Result<Key, std::io::Error>>, W: Write> Game<R, W> {
     ///
     /// This will listen to events and do the appropriate actions.
     fn start(&mut self) {
+        let mut first_click = true;
         loop {
             // Read a single byte from stdin.
             let b = self.stdin.next().unwrap().unwrap();
@@ -209,6 +210,24 @@ impl<R: Iterator<Item=Result<Key, std::io::Error>>, W: Write> Game<R, W> {
                 Char(' ') => {
                     // Check if it was a mine.
                     let (x, y) = (self.x, self.y);
+                    if first_click {
+						loop {
+							for &(x, y) in self.adjacent(x, y).iter() {
+								if self.get(x, y).mine {
+									for i in 0..self.grid.len() {
+										self.grid[i] = Cell {
+											mine: false,
+											revealed: false,
+											observed: false,
+										};
+									}
+									continue;
+								}
+							}
+							break;
+						}
+						first_click = false;
+					}
                     if self.get(x, y).mine {
                         self.game_over();
                         return;


### PR DESCRIPTION
There are no mines around the place you clicked on first. This makes it so you cannot click on a mine with your first click and you will always clear at least 9 squares(It does not work after you restart with 'r').