### PR TITLE
Show cursor when exiting game

### DIFF
--- a/src/snake/main.rs
+++ b/src/snake/main.rs
@@ -440,7 +440,7 @@ fn init(width: usize, height: usize) {
     game.reset();
     game.start();
 
-    write!(game.stdout, "{}{}{}", clear::All, style::Reset, cursor::Goto(1, 1)).unwrap();
+    write!(game.stdout, "{}{}{}{}", clear::All, style::Reset, cursor::Show, cursor::Goto(1, 1)).unwrap();
     game.stdout.flush().unwrap();
 }
 


### PR DESCRIPTION
Fixes issue where leaving the game will result in cursor not showing up in the terminal.